### PR TITLE
Removing Docker and Postman and using Podman and Bruno. Other tweaks …

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `install.sh` script performs the following actions:
 #### For MacOS:
 
 - Installs a variety of Homebrew packages, including `neovim`, `tmux`, `git-extras`, `thefuck`, `go`, `kubectl`, `skaffold`, `awscli`, `terraform`, `packer`, `aws-sam-cli`, `node`, `redis`, and `molecule`.
-- Installs several Homebrew cask packages, including `arc`, `iterm2`, `visual-studio-code`, `1password`, `rectangle`, `font-hack-nerd-font`, `jetbrains-toolbox`, `nordvpn`, `switchresx`, `discord`, `istat-menus`, `signal`, `docker`, `postman`, `gimp`, `obs`, and `krisp`.
+- Installs several Homebrew cask packages, including `arc`, `iterm2`, `visual-studio-code`, `1password`, `rectangle`, `font-hack-nerd-font`, `jetbrains-toolbox`, `nordvpn`, `switchresx`, `discord`, `istat-menus`, `signal`, `podman`, `bruno`, `gimp`, `obs`, and `krisp`.
 
 #### For Debian:
 

--- a/defilan-osconfig/roles/defilan-osconfig/tasks/main.yml
+++ b/defilan-osconfig/roles/defilan-osconfig/tasks/main.yml
@@ -23,6 +23,7 @@
     name: "{{ item }}"
   loop: "{{ config_packages[config].homebrew_cask_packages }}"
   when: ansible_os_family == 'Darwin' and config_packages[config].homebrew_cask_packages is defined
+  ignore_errors: true
 
 # Debian specific tasks
 

--- a/defilan-osconfig/roles/defilan-osconfig/vars/main.yml
+++ b/defilan-osconfig/roles/defilan-osconfig/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # vars file for defilan-macos
-go_version: 1.22.2
+go_version: 1.25.0
 
 config_packages:
   lightweight:
@@ -34,6 +34,10 @@ config_packages:
       - twilio
       - exercism
       - yarn
+      - podman
+      - minikube
+      - kubectx
+      - helm
     homebrew_cask_packages:
       - arc
       - iterm2
@@ -44,8 +48,7 @@ config_packages:
       - jetbrains-toolbox
       - switchresx
       - istat-menus
-      - docker
-      - postman
+      - bruno
       - obs
       - cursor
     apt_packages:
@@ -79,6 +82,10 @@ config_packages:
       - twilio
       - exercism
       - yarn
+      - podman
+      - minikube
+      - kubectx
+      - helm
     homebrew_cask_packages:
       - arc
       - iterm2
@@ -92,13 +99,10 @@ config_packages:
       - discord
       - istat-menus
       - signal
-      - docker
-      - postman
+      - bruno
       - gimp
       - obs
       - krisp
-      - microsoft-office
-      - cursor
     apt_packages:
       - neovim
       - tmux


### PR DESCRIPTION
This update does the following:
1. Removes Docker and Postman
2. Adds Podman and Bruno
3. Adds "ignore_errors" to the brew cask install in the Ansible code to prevent failures that occur if an item is already installed (added from MDM, etc).

